### PR TITLE
ticker: fix TimeNoSecondFractions due to changes in Go 1.9.

### DIFF
--- a/ticker/ticker.go
+++ b/ticker/ticker.go
@@ -83,7 +83,7 @@ func (ticker *TimeTicker) tick() {
 // less, then a second set to 0.
 // ex. 11:22:33.456 --> 11:22:33.000
 func TimeNoSecondFractions(t time.Time) time.Time {
-	return t.Add(-time.Nanosecond * time.Duration(t.Nanosecond()))
+	return time.Unix(t.Unix(), 0)
 }
 
 // TimeNoMinuteFractions returns the time with all time units


### PR DESCRIPTION
The old version is no longer valid due to internal changes in time in Go 1.9.
The following [gist](https://gist.github.com/avdva/9704d8f3786ceea6e5542fff8452e51f) shows, that two times with similar UnixNano's aren't longer equal. This commit fixes the problem.